### PR TITLE
Removed a nowrap to prevent overflow

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -291,7 +291,6 @@ table {
 
 .sidebar td:not(:first-child), .sidebar th:not(:first-child) {
   text-align: right;
-  white-space: nowrap;
 }
 
 .sidebar a {


### PR DESCRIPTION
As you can see on this node's information a long contact information can cause an ugly overflow.
http://map.freifunk-essen.net/meshviewer/#!n:c46e1f2d5a28
Removing the nowrap resolves this issue and does not seem to have any side effect.